### PR TITLE
理应使用 `https://` 来成为一个真正的"跳转链接"？

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 ## 网站投稿功能
 
-计划：在 [submit.transcircle.org](submit.transcircle.org) 实现投稿表单。
+计划：在 [submit.transcircle.org](https://submit.transcircle.org) 实现投稿表单。
 
 - [ ] Serverless 投稿表单
 


### PR DESCRIPTION
## 做出的更改
<img width="1357" height="312" alt="image" src="https://github.com/user-attachments/assets/4700525c-2f38-4121-acf5-1fa5b4a5d6b2" />
将：
> 计划：在 [submit.transcircle.org](submit.transcircle.org) 实现投稿表单。
改为：
> 计划：在 [submit.transcircle.org](https://submit.transcircle.org) 实现投稿表单。
否则，点击链接时，跳转的是：
<img width="460" height="45" alt="image" src="https://github.com/user-attachments/assets/c932b9c1-cb63-4b37-b3a7-46d66421976b" />


## 注意：
> [!warning]
> 虽然我这样的确修复了格式，但是 `https://submit.transcircle.org` 网站里好像什么都没有？