### PR TITLE
:bug: fix(a11y): use theme-aware hover backgrounds for CTA and social links

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -140,14 +140,14 @@
 }
 
 .ctaSecondary:hover {
-  background-color: #ffedf1;
+  background-color: var(--hover-bg);
   color: var(--accent-pink);
   border-color: var(--accent-pink);
 }
 
 @supports (background-color: color-mix(in srgb, red 15%, white)) {
   .ctaSecondary:hover {
-    background-color: color-mix(in srgb, var(--primary-pink) 15%, white);
+    background-color: var(--hover-bg-mix);
   }
 }
 
@@ -174,12 +174,12 @@
 }
 
 .socialLink:hover {
-  background-color: #ffedf1;
+  background-color: var(--hover-bg);
 }
 
 @supports (background-color: color-mix(in srgb, red 15%, white)) {
   .socialLink:hover {
-    background-color: color-mix(in srgb, var(--primary-pink) 15%, white);
+    background-color: var(--hover-bg-mix);
   }
 }
 


### PR DESCRIPTION
## BUG
<img width="572" height="198" alt="image" src="https://github.com/user-attachments/assets/e4cfcb26-9b50-488e-9ea9-eace9736059f" />
<img width="578" height="433" alt="image" src="https://github.com/user-attachments/assets/60f818f2-d0f9-44fd-b007-507b424d8af7" />


## Summary
- `.ctaSecondary:hover` 和 `.socialLink:hover` 的 hover 背景在深色模式下显示为白色，导致同色文字不可读
- 将硬编码的 `#ffedf1` / `color-mix(..., white)` 替换为已在 `index.css` 中按主题定义好的 `--hover-bg` / `--hover-bg-mix` 变量
- 结果：
<img width="866" height="257" alt="image" src="https://github.com/user-attachments/assets/171e5d64-6d6a-4fa9-abcb-b70e229747c4" />
<img width="602" height="474" alt="image" src="https://github.com/user-attachments/assets/35c7ca4f-dd13-40fc-bd52-67c9f6e810f4" />



## Before / After
| 主题 | Hover 前 | Hover 后 |
|------|-----------|----------|
| Light | 粉色文字 | 浅粉背景 + 粉色文字 ✅ |
| Dark | 粉色文字 | 白色背景 + 白色文字 ❌ → 暗粉背景 + 粉色文字 ✅ |
| Contrast | 琥珀色文字 | 暗琥珀背景 + 琥珀色文字 ✅ |

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] 手动验证深色模式下 hover "加入 X 聊天群" 和三个社交链接是否可读