### PR TITLE
:recycle: fix(nav): redirect stories link to story.transcircle.org, remove WIP label

### DIFF
--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -48,7 +48,7 @@ export function AppNav() {
   // 导航站主导航：首页 + 生态各业务分区（沿用原导航站，故事征集/人物归档/社群互助）。
   const primaryLinks: NavLinkDef[] = [
     { label: t("nav.home"), to: "/" },
-    { label: t("nav.stories"), href: "/#stories" },
+    { label: t("nav.stories"), href: "https://story.transcircle.org/" },
     { label: t("nav.archive"), href: "/#archive" },
     { label: t("nav.community"), href: "/#community" },
   ];

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -70,7 +70,7 @@
     "links": "链接",
     "blog": "博客",
     "search": "搜索",
-    "stories": "故事征集（开发中）",
+    "stories": "故事征集",
     "archive": "人物归档（开发中）",
     "community": "社群互助（开发中）"
   },

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -70,7 +70,7 @@
     "links": "連結",
     "blog": "部落格",
     "search": "搜尋",
-    "stories": "故事徵集（開發中）",
+    "stories": "故事徵集",
     "archive": "人物歸檔（開發中）",
     "community": "社群互助（開發中）"
   },


### PR DESCRIPTION
- 导航栏「故事征集」去掉（开发中）标记
- 点击后跳转到 https://story.transcircle.org ，（而非锚点 /#stories）