### PR TITLE
Fix session-expiry feedback and auth isolation

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -237,7 +237,6 @@ async function handle401(
       }
     }
     _userToken = null;
-    clearAdminAuth();
     dispatchAuthEvent("pass:session-expired");
   } else {
     clearAdminAuth();

--- a/src/context/SessionContext.tsx
+++ b/src/context/SessionContext.tsx
@@ -14,7 +14,6 @@ import {
 import {
   api,
   clearUserAuth,
-  clearAdminAuth,
   setUserToken,
   tryRefreshToken,
 } from "../api/client";
@@ -23,6 +22,9 @@ import type { MeProfile } from "../api/types";
 interface SessionContextValue {
   user: MeProfile | null;
   loading: boolean;
+  /** 会话因失效被清除；受保护页面据此给登录页一次性反馈。 */
+  sessionExpired: boolean;
+  clearSessionExpired: () => void;
   /** 重新拉取 /v1/me（登录/资料更新后调用）。返回最新用户或 null。 */
   refresh: () => Promise<MeProfile | null>;
   /** 乐观更新本地用户。 */
@@ -36,6 +38,8 @@ const SessionContext = createContext<SessionContextValue | null>(null);
 export const SessionProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<MeProfile | null>(null);
   const [loading, setLoading] = useState(true);
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const clearSessionExpired = useCallback(() => setSessionExpired(false), []);
 
   const refresh = useCallback(async (): Promise<MeProfile | null> => {
     const res = await api.get<MeProfile>("/v1/me");
@@ -52,7 +56,6 @@ export const SessionProvider = ({ children }: { children: ReactNode }) => {
     // 不再静默吞掉失败：上抛给调用方（AppNav 已有 catch 反馈），避免服务端会话
     // 仍存活的「假登出」。会话本已失效(401)时,客户端会经 session-expired 事件清态。
     if (!res.ok) throw new Error(res.error.message);
-    clearAdminAuth();
     clearUserAuth();
     setUser(null);
   }, []);
@@ -88,13 +91,18 @@ export const SessionProvider = ({ children }: { children: ReactNode }) => {
 
   // 监听 401 自动失效（refresh 兑换失败）。
   useEffect(() => {
-    const onExpired = () => setUser(null);
+    const onExpired = () => {
+      setUser(null);
+      setSessionExpired(true);
+    };
     window.addEventListener("pass:session-expired", onExpired);
     return () => window.removeEventListener("pass:session-expired", onExpired);
   }, []);
 
   return (
-    <SessionContext.Provider value={{ user, loading, refresh, setUser, logout }}>
+    <SessionContext.Provider
+      value={{ user, loading, sessionExpired, clearSessionExpired, refresh, setUser, logout }}
+    >
       {children}
     </SessionContext.Provider>
   );

--- a/src/i18n/locales/zh-CN/common.json
+++ b/src/i18n/locales/zh-CN/common.json
@@ -138,7 +138,8 @@
     "adminEntry": "管理员登录（IAM）",
     "mfaChallengeMissing": "登录需要多因素验证，但服务器未返回验证挑战，请重试；若问题持续请联系管理员。",
     "captchaRequired": "登录尝试过于频繁，请完成人机验证",
-    "captchaFailed": "人机验证失败，请重试"
+    "captchaFailed": "人机验证失败，请重试",
+    "sessionExpired": "会话已结束，请重新登录。"
   },
   "register": {
     "title": "创建账户",

--- a/src/i18n/locales/zh-TW/common.json
+++ b/src/i18n/locales/zh-TW/common.json
@@ -138,7 +138,8 @@
     "adminEntry": "管理員登入（IAM）",
     "mfaChallengeMissing": "登入需要多因素驗證，但伺服器未返回驗證挑戰，請重試；若問題持續請聯絡管理員。",
     "captchaRequired": "登入嘗試過於頻繁，請完成人機驗證",
-    "captchaFailed": "人機驗證失敗，請重試"
+    "captchaFailed": "人機驗證失敗，請重試",
+    "sessionExpired": "工作階段已結束，請重新登入。"
   },
   "register": {
     "title": "建立賬戶",

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -49,10 +49,11 @@ type PendingAction = "login" | "mfa" | "mfaPasskey" | "github" | "x" | "passkey"
 const LoginPage = () => {
   const { t } = useTranslation();
   const navigate = useNavigate();
-  const { user, refresh } = useSession();
+  const { user, refresh, sessionExpired, clearSessionExpired } = useSession();
   const [params] = useSearchParams();
 
   const oidcUid = params.get("oidc");
+  const showSessionExpired = params.get("reason") === "session_expired" && sessionExpired;
   // 来自 URL 的重定向目标必须净化，防开放重定向。
   const redirectTo = sanitizeRedirect(params.get("redirect"), "/account");
 
@@ -109,6 +110,7 @@ const LoginPage = () => {
 
   const onTokens = async (data: LoginResult) => {
     clearAdminAuth();
+    clearSessionExpired();
     if (data.accessToken) setUserToken(data.accessToken);
     setTurnstileToken(null);
     await refresh();
@@ -303,6 +305,7 @@ const LoginPage = () => {
     <CenteredCard>
       <PageHeader align="center" title={oidcUid ? t("login.oidcTitle") : t("login.title")} />
 
+      {showSessionExpired && <Alert tone="error">{t("login.sessionExpired")}</Alert>}
       {error && <Alert tone="error">{error}</Alert>}
 
       {!mfaToken ? (

--- a/src/pages/account/AccountPage.tsx
+++ b/src/pages/account/AccountPage.tsx
@@ -29,7 +29,7 @@ const PencilIcon = () => (
  */
 const AccountPage = () => {
   const { t } = useTranslation();
-  const { user, loading } = useSession();
+  const { user, loading, sessionExpired } = useSession();
   const location = useLocation();
   const [avatarOpen, setAvatarOpen] = useState(false);
 
@@ -39,7 +39,9 @@ const AccountPage = () => {
     return <StatusScreen kind="loading" title={t("account.verifying")} />;
   }
   if (!user) {
-    return <Navigate to={`/login?redirect=${encodeURIComponent(location.pathname)}`} replace />;
+    const params = new URLSearchParams({ redirect: location.pathname });
+    if (sessionExpired) params.set("reason", "session_expired");
+    return <Navigate to={`/login?${params.toString()}`} replace />;
   }
 
   const displayName = user.displayName || user.username;


### PR DESCRIPTION
## Summary
Keep user-session expiry isolated from administrator authentication and explain expired sessions to users.

## Key changes
- Stop clearing the administrator token when user-plane authentication expires or the user logs out.
- Track one-time user-session expiry state in `SessionContext`.
- Pass a controlled session-expired reason through the protected account redirect.
- Display localized Simplified and Traditional Chinese feedback on the login page and clear it after successful sign-in.

## Testing
- Existing Vitest suite passed: 1 test file, 13 tests.
- TypeScript passed.
- Production build passed.
- `git diff --check` passed.

## Follow-ups
- Add focused session-expiry and administrator-auth-isolation tests.
- Add repository-level lint, test, typecheck, and PR CI scripts in a separate tooling change.